### PR TITLE
docs(contrib): purposefully use invalid link

### DIFF
--- a/docs/src/contrib/contributing.md
+++ b/docs/src/contrib/contributing.md
@@ -9,7 +9,7 @@
 [doc-tests]: ./tests/intro.md
 [doc-themes]: ./themes.md
 [garnix]: https://garnix.io
-[git-hooks]: https://git-scm.com/book/en/v2/Customizing-Git-Git-Hooks
+[git-hooks]: https://git-scm.com/book/en/v2/Customizing-Git-Git-Hook
 [github-coc]: https://github.com/nicolas-goudry/nixkraken/blob/main/CODE_OF_CONDUCT.md
 [github-fork]: https://github.com/nicolas-goudry/nixkraken/fork
 [github-hooks]: https://github.com/nicolas-goudry/nixkraken/blob/main/.hooks


### PR DESCRIPTION
## Description

This PR aims to check the recent documentation check job.

**THIS MUST NOT BE MERGED!**